### PR TITLE
Minor bump vision sdk 0.3.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://www.mapbox.com/ios-sdk/opencv.json" ~> 2.4.13
-binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" == 0.3.0
+binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" == 0.2.0
 github "marmelroy/Zip" ~> 1.1.0
 github "mapbox/mapbox-events-ios" ~> 0.8.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://www.mapbox.com/ios-sdk/opencv.json" ~> 2.4.13
 binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" == 0.2.0
 github "marmelroy/Zip" ~> 1.1.0
-github "mapbox/mapbox-events-ios" ~> 0.6.0
+github "mapbox/mapbox-events-ios" ~> 0.8.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://www.mapbox.com/ios-sdk/opencv.json" ~> 2.4.13
-binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" == 0.2.0
+binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" == 0.3.0
 github "marmelroy/Zip" ~> 1.1.0
 github "mapbox/mapbox-events-ios" ~> 0.8.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "https://www.mapbox.com/ios-sdk/MapboxVisionCore.json" "0.2.0"
 binary "https://www.mapbox.com/ios-sdk/opencv.json" "2.4.13"
-github "mapbox/mapbox-events-ios" "v0.6.0"
+github "mapbox/mapbox-events-ios" "v0.8.1"
 github "marmelroy/Zip" "1.1.0"

--- a/MapboxVision.podspec
+++ b/MapboxVision.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MapboxVision"
-  s.version      = "0.2.0"
+  s.version      = "0.3.0"
   s.summary      = "ML empowered vision framework"
 
   s.homepage     = 'https://www.mapbox.com/vision/'
@@ -24,8 +24,8 @@ Pod::Spec.new do |s|
 
   s.swift_version = '4.1'
 
-  s.dependency "MapboxVisionCore", "= 0.2.0"
+  s.dependency "MapboxVisionCore", "= 0.3.0"
   s.dependency "Zip",   "~> 1.1.0"
-  s.dependency "MapboxMobileEvents", "~> 0.6.0"
+  s.dependency "MapboxMobileEvents", "~> 0.8.1"
 
 end

--- a/MapboxVision.podspec
+++ b/MapboxVision.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MapboxVision"
-  s.version      = "0.3.0"
+  s.version      = "0.2.1"
   s.summary      = "ML empowered vision framework"
 
   s.homepage     = 'https://www.mapbox.com/vision/'
@@ -24,8 +24,8 @@ Pod::Spec.new do |s|
 
   s.swift_version = '4.1'
 
-  s.dependency "MapboxVisionCore", "~> 0.2.0"
-  s.dependency "Zip",   "~> 1.1.0"
+  s.dependency "MapboxVisionCore", "= 0.2.0"
+  s.dependency "Zip", "~> 1.1.0"
   s.dependency "MapboxMobileEvents", "~> 0.8.1"
 
 end

--- a/MapboxVision.podspec
+++ b/MapboxVision.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '4.1'
 
-  s.dependency "MapboxVisionCore", "= 0.3.0"
+  s.dependency "MapboxVisionCore", "~> 0.3.0"
   s.dependency "Zip",   "~> 1.1.0"
   s.dependency "MapboxMobileEvents", "~> 0.8.1"
 

--- a/MapboxVision.podspec
+++ b/MapboxVision.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '4.1'
 
-  s.dependency "MapboxVisionCore", "~> 0.3.0"
+  s.dependency "MapboxVisionCore", "~> 0.2.0"
   s.dependency "Zip",   "~> 1.1.0"
   s.dependency "MapboxMobileEvents", "~> 0.8.1"
 

--- a/MapboxVision/Info.plist
+++ b/MapboxVision/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MapboxVision/Info.plist
+++ b/MapboxVision/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MapboxVisionTests/Info.plist
+++ b/MapboxVisionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
This a `minor` bump because the dependent SDK, `"MapboxMobileEvents"` have gone through a series of minor releases `~> 0.6.0` - `~> 0.8.1` since its last update. 

cc @chezzdev 