### PR TITLE
Run models on iPhone Xr/Xs/Xs Max with higher fps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - Changed World-Pixel transformation methods to return optional values
 - Changed World-Geo transformation methods to return optional values
 - Changed implementation of `DeviceInfoProvider` provider in order to make device's id persistent
-- Removed `MapboxNavigation` dependency
+- Changed implementation of `DeviceChecker` to increase performance on devices with A12 Bionic SoC
 - Fixed deleting binary telemetry while moving it after recording is finished
+- Removed `MapboxNavigation` dependency
 
 ## 0.4.1
 

--- a/MapboxVision.xcodeproj/project.pbxproj
+++ b/MapboxVision.xcodeproj/project.pbxproj
@@ -1359,7 +1359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = MapboxVisionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1381,7 +1381,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = MapboxVisionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1402,7 +1402,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = MapboxVisionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MapboxVision.xcodeproj/project.pbxproj
+++ b/MapboxVision.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		2EDFFD73224BBD3E003BB718 /* ObservableVideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDFFD72224BBD3E003BB718 /* ObservableVideoSource.swift */; };
 		2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */; };
 		2EFF563F210B4A5B00B8D512 /* VideoTrimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF563E210B4A5B00B8D512 /* VideoTrimmer.swift */; };
+		3A11FEDF2282BCD300B68E5B /* DeviceCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */; };
 		9D72A196BCA3C43852E39A10 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A773F7BCE045156649B6 /* DateFormatter.swift */; };
 		9D72A4A4A30F19F3EA8A7316 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A9D70E54F426D0E8990E /* VideoSource.swift */; };
 		9D72A5C114A06457134C5EE5 /* RecordSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72AEC4FF135C1A496B5215 /* RecordSynchronizer.swift */; };
@@ -189,6 +190,7 @@
 		2EDFFD72224BBD3E003BB718 /* ObservableVideoSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableVideoSource.swift; sourceTree = "<group>"; };
 		2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinatorTests.swift; sourceTree = "<group>"; };
 		2EFF563E210B4A5B00B8D512 /* VideoTrimmer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTrimmer.swift; sourceTree = "<group>"; };
+		3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCheckerTests.swift; sourceTree = "<group>"; };
 		9D72A5D7CECFACCEE667A42B /* CVPixelBuffer+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Helper.swift"; sourceTree = "<group>"; };
 		9D72A648B7F1E55B41E25240 /* CameraVideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraVideoSource.swift; sourceTree = "<group>"; };
 		9D72A773F7BCE045156649B6 /* DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 				B51E557B215E313500650DDE /* RecordSynchronizerTests.swift */,
 				2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */,
 				2EDD8708219EDC0200760C6D /* DeviceInfoProviderTests.swift */,
+				3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */,
 				B51E557D215E313500650DDE /* Info.plist */,
 				2E1FC07A22D4BE1A009BEBFB /* RecordingPathTests.swift */,
 			);
@@ -887,6 +890,7 @@
 				B51E557C215E313500650DDE /* RecordSynchronizerTests.swift in Sources */,
 				2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */,
 				B50CFBAD2163C91500C9C5A5 /* MockNetworkClient.swift in Sources */,
+				3A11FEDF2282BCD300B68E5B /* DeviceCheckerTests.swift in Sources */,
 				B50CFBAF2163C98E00C9C5A5 /* MockRecordDataSource.swift in Sources */,
 				B50CFBB12163C9AC00C9C5A5 /* MockArchiver.swift in Sources */,
 				B50CFBB32163C9C500C9C5A5 /* MockFileManager.swift in Sources */,

--- a/MapboxVision.xcodeproj/project.pbxproj
+++ b/MapboxVision.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */; };
 		2EFF563F210B4A5B00B8D512 /* VideoTrimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF563E210B4A5B00B8D512 /* VideoTrimmer.swift */; };
 		3A11FEDF2282BCD300B68E5B /* DeviceCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */; };
+		3AAB2EFB22858F28000D052E /* UIDeviceStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAB2EFA22858F28000D052E /* UIDeviceStubs.swift */; };
 		9D72A196BCA3C43852E39A10 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A773F7BCE045156649B6 /* DateFormatter.swift */; };
 		9D72A4A4A30F19F3EA8A7316 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A9D70E54F426D0E8990E /* VideoSource.swift */; };
 		9D72A5C114A06457134C5EE5 /* RecordSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72AEC4FF135C1A496B5215 /* RecordSynchronizer.swift */; };
@@ -191,6 +192,7 @@
 		2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinatorTests.swift; sourceTree = "<group>"; };
 		2EFF563E210B4A5B00B8D512 /* VideoTrimmer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTrimmer.swift; sourceTree = "<group>"; };
 		3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCheckerTests.swift; sourceTree = "<group>"; };
+		3AAB2EFA22858F28000D052E /* UIDeviceStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceStubs.swift; sourceTree = "<group>"; };
 		9D72A5D7CECFACCEE667A42B /* CVPixelBuffer+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Helper.swift"; sourceTree = "<group>"; };
 		9D72A648B7F1E55B41E25240 /* CameraVideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraVideoSource.swift; sourceTree = "<group>"; };
 		9D72A773F7BCE045156649B6 /* DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
@@ -520,6 +522,7 @@
 				B50CFBAE2163C98E00C9C5A5 /* MockRecordDataSource.swift */,
 				B50CFBB02163C9AC00C9C5A5 /* MockArchiver.swift */,
 				B50CFBB22163C9C500C9C5A5 /* MockFileManager.swift */,
+				3AAB2EFA22858F28000D052E /* UIDeviceStubs.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -886,6 +889,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AAB2EFB22858F28000D052E /* UIDeviceStubs.swift in Sources */,
 				2E1FC07B22D4BE1A009BEBFB /* RecordingPathTests.swift in Sources */,
 				B51E557C215E313500650DDE /* RecordSynchronizerTests.swift in Sources */,
 				2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */,

--- a/MapboxVision.xcodeproj/project.pbxproj
+++ b/MapboxVision.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF31C8F21904BB300752D23 /* RecordCoordinatorTests.swift */; };
 		2EFF563F210B4A5B00B8D512 /* VideoTrimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF563E210B4A5B00B8D512 /* VideoTrimmer.swift */; };
 		3A11FEDF2282BCD300B68E5B /* DeviceCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A11FEDE2282BCD300B68E5B /* DeviceCheckerTests.swift */; };
+		3A7676AE22D647FE00ABC483 /* DeviceChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E19772A211DDD5900311B95 /* DeviceChecker.swift */; };
 		3AAB2EFB22858F28000D052E /* UIDeviceStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAB2EFA22858F28000D052E /* UIDeviceStubs.swift */; };
 		9D72A196BCA3C43852E39A10 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A773F7BCE045156649B6 /* DateFormatter.swift */; };
 		9D72A4A4A30F19F3EA8A7316 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D72A9D70E54F426D0E8990E /* VideoSource.swift */; };
@@ -895,6 +896,7 @@
 				2EF31C9021904BB300752D23 /* RecordCoordinatorTests.swift in Sources */,
 				B50CFBAD2163C91500C9C5A5 /* MockNetworkClient.swift in Sources */,
 				3A11FEDF2282BCD300B68E5B /* DeviceCheckerTests.swift in Sources */,
+				3A7676AE22D647FE00ABC483 /* DeviceChecker.swift in Sources */,
 				B50CFBAF2163C98E00C9C5A5 /* MockRecordDataSource.swift in Sources */,
 				B50CFBB12163C9AC00C9C5A5 /* MockArchiver.swift in Sources */,
 				B50CFBB32163C9C500C9C5A5 /* MockFileManager.swift in Sources */,

--- a/MapboxVision/Helpers/DeviceChecker.swift
+++ b/MapboxVision/Helpers/DeviceChecker.swift
@@ -2,29 +2,33 @@ import Foundation
 import MapboxVisionNative
 import UIKit
 
-private let iPhoneName = "iPhone"
-private let iPhoneMinModel = 10 // meaning iPhone 8/8Plus/X
+enum DeviceModel {
+    enum Name {
+        static let iPhone = "iPhone"
+    }
+
+    enum MajorNumber {
+        static let minIphoneVersionWithHighPerformance = 10 // "10" corresponds to 8/8 Plus/X.
+        static let maxIphoneVersionWithHighPerformance = 11 // "11" corresponds to XR/XS/Xs Max.
+    }
+}
 
 extension UIDevice {
-    var isTopDevice: Bool {
-        var prefix: String = ""
-        var minModel: Int = 0
+     // By default we consider next-gen iPhone as a uncapable to run models with high performance.
+     // This is due to potential issues with temperature during operational mode.
+     // We must do proper testing before upgrading `maxIphoneVersionWithHighPerformance`.
+    var isHighPerformance: Bool {
+        let modelID = self.modelID
 
-        var modelID = self.modelID
-
-        if modelID.hasPrefix(iPhoneName) {
-            prefix = iPhoneName
-            minModel = iPhoneMinModel
+        guard
+            modelID.hasPrefix(DeviceModel.Name.iPhone),
+            let currentModelMajorVersion = modelID.dropFirst(DeviceModel.Name.iPhone.count).split(separator: ",").first,
+            let currentModelMajorNumber = Int(currentModelMajorVersion) else
+        {
+            return false
         }
 
-        guard !prefix.isEmpty, minModel > 0 else { return false }
-
-        modelID.removeFirst(prefix.count)
-
-        if let majorVersion = modelID.split(separator: ",").first, let majorNumber = Int(majorVersion) {
-            return majorNumber == minModel
-        }
-
-        return false
+        return currentModelMajorNumber >= DeviceModel.MajorNumber.minIphoneVersionWithHighPerformance &&
+               currentModelMajorNumber <= DeviceModel.MajorNumber.maxIphoneVersionWithHighPerformance
     }
 }

--- a/MapboxVision/Helpers/DeviceChecker.swift
+++ b/MapboxVision/Helpers/DeviceChecker.swift
@@ -2,7 +2,7 @@ import Foundation
 import MapboxVisionNative
 import UIKit
 
-enum DeviceModel {
+private enum DeviceModel {
     enum Name {
         static let iPhone = "iPhone"
     }

--- a/MapboxVision/Helpers/DeviceChecker.swift
+++ b/MapboxVision/Helpers/DeviceChecker.swift
@@ -14,9 +14,9 @@ private enum DeviceModel {
 }
 
 extension UIDevice {
-     // By default we consider next-gen iPhone as a uncapable to run models with high performance.
-     // This is due to potential issues with temperature during operational mode.
-     // We must do proper testing before upgrading `maxIphoneVersionWithHighPerformance`.
+    // By default we consider next-gen iPhone as a uncapable to run models with high performance.
+    // This is due to potential issues with temperature during operational mode.
+    // We must do proper testing before upgrading `maxIphoneVersionWithHighPerformance`.
     var isHighPerformance: Bool {
         let modelID = self.modelID
 
@@ -29,6 +29,6 @@ extension UIDevice {
         }
 
         return currentModelMajorNumber >= DeviceModel.MajorNumber.minIphoneVersionWithHighPerformance &&
-               currentModelMajorNumber <= DeviceModel.MajorNumber.maxIphoneVersionWithHighPerformance
+            currentModelMajorNumber <= DeviceModel.MajorNumber.maxIphoneVersionWithHighPerformance
     }
 }

--- a/MapboxVision/Services/ModelPerformance.swift
+++ b/MapboxVision/Services/ModelPerformance.swift
@@ -125,7 +125,7 @@ enum ModelPerformanceResolver {
         }
     }
 
-    private static let isTopDevice = UIDevice.current.isTopDevice
+    private static let isHighPerformanceIphone = UIDevice.current.isTopDevice
 
     private static let segmentationHighEnd = PerformanceEntry(off: 1, low: 2, high: 7)
     private static let    detectionHighEnd = PerformanceEntry(off: 3, low: 4, high: 12)
@@ -136,9 +136,9 @@ enum ModelPerformanceResolver {
     private static func performanceEntry(for model: ModelType) -> PerformanceEntry {
         switch model {
         case .segmentation:
-            return isTopDevice ? segmentationHighEnd : segmentationLowEnd
+            return isHighPerformanceIphone ? segmentationHighEnd : segmentationLowEnd
         case .detection:
-            return isTopDevice ? detectionHighEnd : detectionLowEnd
+            return isHighPerformanceIphone ? detectionHighEnd : detectionLowEnd
         }
     }
 

--- a/MapboxVision/Services/ModelPerformance.swift
+++ b/MapboxVision/Services/ModelPerformance.swift
@@ -124,21 +124,21 @@ enum ModelPerformanceResolver {
             }
         }
     }
-
-    private static let isHighPerformanceIphone = UIDevice.current.isTopDevice
-
-    private static let segmentationHighEnd = PerformanceEntry(off: 1, low: 2, high: 7)
-    private static let    detectionHighEnd = PerformanceEntry(off: 3, low: 4, high: 12)
-
-    private static let  segmentationLowEnd = PerformanceEntry(off: 1, low: 2, high: 5)
-    private static let     detectionLowEnd = PerformanceEntry(off: 3, low: 4, high: 11)
+    
+    private static let isHighPerformance = UIDevice.current.isHighPerformance
+    
+    private static let segmentationHighEnd   = PerformanceEntry(off: 1, low: 2, high: 7)
+    private static let detectionHighEnd      = PerformanceEntry(off: 3, low: 4, high: 12)
+    
+    private static let segmentationLowEnd    = PerformanceEntry(off: 1, low: 2, high: 5)
+    private static let detectionLowEnd       = PerformanceEntry(off: 3, low: 4, high: 11)
 
     private static func performanceEntry(for model: ModelType) -> PerformanceEntry {
         switch model {
         case .segmentation:
-            return isHighPerformanceIphone ? segmentationHighEnd : segmentationLowEnd
+            return isHighPerformance ? segmentationHighEnd : segmentationLowEnd
         case .detection:
-            return isHighPerformanceIphone ? detectionHighEnd : detectionLowEnd
+            return isHighPerformance ? detectionHighEnd : detectionLowEnd
         }
     }
 

--- a/MapboxVision/Services/ModelPerformance.swift
+++ b/MapboxVision/Services/ModelPerformance.swift
@@ -124,14 +124,14 @@ enum ModelPerformanceResolver {
             }
         }
     }
-    
+
     private static let isHighPerformance = UIDevice.current.isHighPerformance
-    
-    private static let segmentationHighEnd   = PerformanceEntry(off: 1, low: 2, high: 7)
-    private static let detectionHighEnd      = PerformanceEntry(off: 3, low: 4, high: 12)
-    
-    private static let segmentationLowEnd    = PerformanceEntry(off: 1, low: 2, high: 5)
-    private static let detectionLowEnd       = PerformanceEntry(off: 3, low: 4, high: 11)
+
+    private static let segmentationHighEnd = PerformanceEntry(off: 1, low: 2, high: 7)
+    private static let    detectionHighEnd = PerformanceEntry(off: 3, low: 4, high: 12)
+
+    private static let  segmentationLowEnd = PerformanceEntry(off: 1, low: 2, high: 5)
+    private static let     detectionLowEnd = PerformanceEntry(off: 3, low: 4, high: 11)
 
     private static func performanceEntry(for model: ModelType) -> PerformanceEntry {
         switch model {

--- a/MapboxVisionTests/DeviceCheckerTests.swift
+++ b/MapboxVisionTests/DeviceCheckerTests.swift
@@ -1,0 +1,30 @@
+//
+//  Created by Dersim Davaod on 5/8/19.
+//  Copyright © 2019 Mapbox. All rights reserved.
+//
+
+import XCTest
+
+class DeviceCheckerTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/MapboxVisionTests/DeviceCheckerTests.swift
+++ b/MapboxVisionTests/DeviceCheckerTests.swift
@@ -3,28 +3,108 @@
 //  Copyright © 2019 Mapbox. All rights reserved.
 //
 
+import Foundation
 import XCTest
+@testable import MapboxVision
 
 class DeviceCheckerTests: XCTestCase {
+    func testIsHighPerformanceDeviceReturnsFalseOnIphone7PlusOrLower() {
+        // Given iPhone 5s (GSM)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone5sGSMStub().isHighPerformanceIphone)
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        // Given iPhone 5s (Global)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone5sGlobalStub().isHighPerformanceIphone)
+
+        // Given iPhone 6 Plus
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone6PlusStub().isHighPerformanceIphone)
+
+        // Given iPhone 6
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone6Stub().isHighPerformanceIphone)
+
+        // Given iPhone 6s
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone6sStub().isHighPerformanceIphone)
+
+        // Given iPhone 6s Plus
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone6sPlusStub().isHighPerformanceIphone)
+
+        // Given iPhone SE
+        // When // Then
+        XCTAssertFalse(UIDeviceIphoneSEStub().isHighPerformanceIphone)
+
+        // Given iPhone 7 (CDMA)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone7CDMAStub().isHighPerformanceIphone)
+
+        // Given iPhone 7 (GSM)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone7GSMStub().isHighPerformanceIphone)
+
+        // Given iPhone 7 Plus (CDMA)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone7PlusCDMAStub().isHighPerformanceIphone)
+
+        // Given iPhone 7 Plus (GSM)
+        // When // Then
+        XCTAssertFalse(UIDeviceIphone7PlusGSMStub().isHighPerformanceIphone)
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testIsHighPerformanceDeviceReturnsTrueOnIphone8OrHigher() {
+        // Given iPhone 8 (CDMA)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphone8CDMAStub().isHighPerformanceIphone)
+
+        // Given iPhone 8 (GSM)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphone8GSMStub().isHighPerformanceIphone)
+
+        // Given iPhone 8 Plus (CDMA)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphone8PlusCDMAStub().isHighPerformanceIphone)
+
+        // Given iPhone 8 Plus (GSM)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphone8PlusGSMStub().isHighPerformanceIphone)
+
+        // Given iPhone X (CDMA)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXCDMAStub().isHighPerformanceIphone)
+
+        // Given iPhone X (GSM)
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXGSMStub().isHighPerformanceIphone)
+
+        // Given iPhone XS
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXSStub().isHighPerformanceIphone)
+
+        // Given iPhone XS Max
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXSMaxStub().isHighPerformanceIphone)
+
+        // Given iPhone XS Max China
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXSMaxChinaStub().isHighPerformanceIphone)
+
+        // Given iPhone XR
+        // When // Then
+        XCTAssertTrue(UIDeviceIphoneXRStub().isHighPerformanceIphone)
     }
 
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testIsHighPerformanceDeviceReturnsFalseOnIphoneNextGeneration() {
+        // Given iPhone next gen model
+        // When // Then
+        XCTAssertFalse(UIDeviceIphoneNextGenerationStub().isHighPerformanceIphone)
     }
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testIsHighPerformanceDeviceReturnsFalseOnIpadDevice() {
+        // Given iPad model
+        // When // Then
+        XCTAssertFalse(UIDeviceIpadStub().isHighPerformanceIphone)
     }
-
 }

--- a/MapboxVisionTests/DeviceCheckerTests.swift
+++ b/MapboxVisionTests/DeviceCheckerTests.swift
@@ -11,100 +11,100 @@ class DeviceCheckerTests: XCTestCase {
     func testIsHighPerformanceDeviceReturnsFalseOnIphone7PlusOrLower() {
         // Given iPhone 5s (GSM)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone5sGSMStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone5sGSMStub().isHighPerformance)
 
         // Given iPhone 5s (Global)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone5sGlobalStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone5sGlobalStub().isHighPerformance)
 
         // Given iPhone 6 Plus
         // When // Then
-        XCTAssertFalse(UIDeviceIphone6PlusStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone6PlusStub().isHighPerformance)
 
         // Given iPhone 6
         // When // Then
-        XCTAssertFalse(UIDeviceIphone6Stub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone6Stub().isHighPerformance)
 
         // Given iPhone 6s
         // When // Then
-        XCTAssertFalse(UIDeviceIphone6sStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone6sStub().isHighPerformance)
 
         // Given iPhone 6s Plus
         // When // Then
-        XCTAssertFalse(UIDeviceIphone6sPlusStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone6sPlusStub().isHighPerformance)
 
         // Given iPhone SE
         // When // Then
-        XCTAssertFalse(UIDeviceIphoneSEStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphoneSEStub().isHighPerformance)
 
         // Given iPhone 7 (CDMA)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone7CDMAStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone7CDMAStub().isHighPerformance)
 
         // Given iPhone 7 (GSM)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone7GSMStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone7GSMStub().isHighPerformance)
 
         // Given iPhone 7 Plus (CDMA)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone7PlusCDMAStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone7PlusCDMAStub().isHighPerformance)
 
         // Given iPhone 7 Plus (GSM)
         // When // Then
-        XCTAssertFalse(UIDeviceIphone7PlusGSMStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphone7PlusGSMStub().isHighPerformance)
     }
 
     func testIsHighPerformanceDeviceReturnsTrueOnIphone8OrHigher() {
         // Given iPhone 8 (CDMA)
         // When // Then
-        XCTAssertTrue(UIDeviceIphone8CDMAStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphone8CDMAStub().isHighPerformance)
 
         // Given iPhone 8 (GSM)
         // When // Then
-        XCTAssertTrue(UIDeviceIphone8GSMStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphone8GSMStub().isHighPerformance)
 
         // Given iPhone 8 Plus (CDMA)
         // When // Then
-        XCTAssertTrue(UIDeviceIphone8PlusCDMAStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphone8PlusCDMAStub().isHighPerformance)
 
         // Given iPhone 8 Plus (GSM)
         // When // Then
-        XCTAssertTrue(UIDeviceIphone8PlusGSMStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphone8PlusGSMStub().isHighPerformance)
 
         // Given iPhone X (CDMA)
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXCDMAStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXCDMAStub().isHighPerformance)
 
         // Given iPhone X (GSM)
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXGSMStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXGSMStub().isHighPerformance)
 
         // Given iPhone XS
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXSStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXSStub().isHighPerformance)
 
         // Given iPhone XS Max
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXSMaxStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXSMaxStub().isHighPerformance)
 
         // Given iPhone XS Max China
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXSMaxChinaStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXSMaxChinaStub().isHighPerformance)
 
         // Given iPhone XR
         // When // Then
-        XCTAssertTrue(UIDeviceIphoneXRStub().isHighPerformanceIphone)
+        XCTAssertTrue(UIDeviceIphoneXRStub().isHighPerformance)
     }
 
     func testIsHighPerformanceDeviceReturnsFalseOnIphoneNextGeneration() {
         // Given iPhone next gen model
         // When // Then
-        XCTAssertFalse(UIDeviceIphoneNextGenerationStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIphoneNextGenerationStub().isHighPerformance)
     }
 
     func testIsHighPerformanceDeviceReturnsFalseOnIpadDevice() {
         // Given iPad model
         // When // Then
-        XCTAssertFalse(UIDeviceIpadStub().isHighPerformanceIphone)
+        XCTAssertFalse(UIDeviceIpadStub().isHighPerformance)
     }
 }

--- a/MapboxVisionTests/DeviceCheckerTests.swift
+++ b/MapboxVisionTests/DeviceCheckerTests.swift
@@ -1,11 +1,6 @@
-//
-//  Created by Dersim Davaod on 5/8/19.
-//  Copyright © 2019 Mapbox. All rights reserved.
-//
-
 import Foundation
-import XCTest
 @testable import MapboxVision
+import XCTest
 
 class DeviceCheckerTests: XCTestCase {
     func testIsHighPerformanceDeviceReturnsFalseOnIphone7PlusOrLower() {

--- a/MapboxVisionTests/Mocks/UIDeviceStubs.swift
+++ b/MapboxVisionTests/Mocks/UIDeviceStubs.swift
@@ -4,3 +4,142 @@
 //
 
 import Foundation
+import MapboxVision
+
+final class UIDeviceIphone5sGSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone6,1"
+    }
+}
+
+final class UIDeviceIphone5sGlobalStub: UIDevice {
+    override var modelID: String {
+        return "iPhone6,2"
+    }
+}
+
+final class UIDeviceIphone6PlusStub: UIDevice {
+    override var modelID: String {
+        return "iPhone7,1"
+    }
+}
+
+final class UIDeviceIphone6Stub: UIDevice {
+    override var modelID: String {
+        return "iPhone7,2"
+    }
+}
+
+final class UIDeviceIphone6sStub: UIDevice {
+    override var modelID: String {
+        return "iPhone8,1"
+    }
+}
+
+final class UIDeviceIphone6sPlusStub: UIDevice {
+    override var modelID: String {
+        return "iPhone8,2"
+    }
+}
+
+final class UIDeviceIphoneSEStub: UIDevice {
+    override var modelID: String {
+        return "iPhone8,4"
+    }
+}
+
+final class UIDeviceIphone7CDMAStub: UIDevice {
+    override var modelID: String {
+        return "iPhone9,1"
+    }
+}
+
+final class UIDeviceIphone7GSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone9,3"
+    }
+}
+
+final class UIDeviceIphone7PlusCDMAStub: UIDevice {
+    override var modelID: String {
+        return "iPhone9,2"
+    }
+}
+
+final class UIDeviceIphone7PlusGSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone9,4"
+    }
+}
+
+final class UIDeviceIphone8CDMAStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,1"
+    }
+}
+
+final class UIDeviceIphone8GSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,4"
+    }
+}
+
+final class UIDeviceIphone8PlusCDMAStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,2"
+    }
+}
+
+final class UIDeviceIphone8PlusGSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,5"
+    }
+}
+
+final class UIDeviceIphoneXCDMAStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,3"
+    }
+}
+
+final class UIDeviceIphoneXGSMStub: UIDevice {
+    override var modelID: String {
+        return "iPhone10,6"
+    }
+}
+
+final class UIDeviceIphoneXSStub: UIDevice {
+    override var modelID: String {
+        return "iPhone11,2"
+    }
+}
+
+final class UIDeviceIphoneXSMaxStub: UIDevice {
+    override var modelID: String {
+        return "iPhone11,4"
+    }
+}
+
+final class UIDeviceIphoneXSMaxChinaStub: UIDevice {
+    override var modelID: String {
+        return "iPhone11,6"
+    }
+}
+
+final class UIDeviceIphoneXRStub: UIDevice {
+    override var modelID: String {
+        return "iPhone11,8"
+    }
+}
+
+final class UIDeviceIphoneNextGenerationStub: UIDevice {
+    override var modelID: String {
+        return "iPhone12,1"
+    }
+}
+
+final class UIDeviceIpadStub: UIDevice {
+    override var modelID: String {
+        return "iPad10,2"
+    }
+}

--- a/MapboxVisionTests/Mocks/UIDeviceStubs.swift
+++ b/MapboxVisionTests/Mocks/UIDeviceStubs.swift
@@ -1,0 +1,6 @@
+//
+//  Created by Dersim Davaod on 5/10/19.
+//  Copyright © 2019 Mapbox. All rights reserved.
+//
+
+import Foundation

--- a/MapboxVisionTests/Mocks/UIDeviceStubs.swift
+++ b/MapboxVisionTests/Mocks/UIDeviceStubs.swift
@@ -1,8 +1,3 @@
-//
-//  Created by Dersim Davaod on 5/10/19.
-//  Copyright © 2019 Mapbox. All rights reserved.
-//
-
 import Foundation
 import MapboxVision
 


### PR DESCRIPTION
NOTE 1:
There're failing tests in `MapboxVisionTests` which are not related to the current PR. The fix will be provided in scope of #89 (UPD: fixed)

NOTE 2:
Should we update implementation of `isHighPerformanceIphone` method to check iPad models as well? (UPD: No)

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
Resolves: #87 
