### PR TITLE
Update VisionARManager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.4.0 (In Development)
+  - `VisionARManager` allows to change ARLane's length

--- a/MapboxVisionAR/VIsionARManager/VisionARManager.swift
+++ b/MapboxVisionAR/VIsionARManager/VisionARManager.swift
@@ -38,7 +38,7 @@ public final class VisionARManager {
     /**
         Setup length of AR lane.
 
-        - Parameter laneLength: length of AR lane in meters.
+        - Parameter laneLength: Length of AR lane in meters.
     */
     func set(laneLength: Double) {
         native?.setLaneLength(laneLength)

--- a/MapboxVisionAR/VIsionARManager/VisionARManager.swift
+++ b/MapboxVisionAR/VIsionARManager/VisionARManager.swift
@@ -34,7 +34,16 @@ public final class VisionARManager {
         manager.delegate = delegate
         return manager
     }
-    
+
+    /**
+        Setup length of AR lane.
+
+        - Parameter laneLength: length of AR lane in meters.
+    */
+    func set(laneLength: Double) {
+        native?.setLaneLength(laneLength)
+    }
+
     /**
         Cleanup the state and resources of `VisionARManger`.
     */


### PR DESCRIPTION
Update VisionARManager API :
`set(laneLength: Double)` method was added.

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
Resolves: #94 