### PR TITLE
Support updated format of MBVDetection object: `boundingBox` now stores relative coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 0.4.0 (In Development)
   - `VisionARManager` allows to change ARLane's length
+  - Support new `MBVDetection` object: `boundingBox` property now stores relative coordinates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.4.0 (In Development)
   - `VisionARManager` allows to change ARLane's length
-  - Support new `MBVDetection` object: `boundingBox` property now stores relative coordinates
+  - `boundingBox` property on `MBVDetection` now stores normalized relative coordinates

--- a/MapboxVision/View/VisionPresentationViewController.swift
+++ b/MapboxVision/View/VisionPresentationViewController.swift
@@ -377,4 +377,11 @@ private extension CGRect {
         let rightBottom = CGPoint(x: maxX, y: maxY).convertForAspectRatioFill(from: from, to: to)
         return CGRect(x: leftTop.x, y: leftTop.y, width: rightBottom.x - leftTop.x, height: rightBottom.y - leftTop.y)
     }
+
+    func convertedToAbsoluteCoordinates(from relativeCoordinates: CGRect, relativeTo frameSize: CGSize) -> CGRect {
+        return CGRect(x: frameSize.width * relativeCoordinates.origin.x,
+                      y: frameSize.height * relativeCoordinates.origin.y,
+                      width: frameSize.width * relativeCoordinates.size.width,
+                      height: frameSize.height * relativeCoordinates.size.height)
+    }
 }

--- a/MapboxVision/View/VisionPresentationViewController.swift
+++ b/MapboxVision/View/VisionPresentationViewController.swift
@@ -362,7 +362,7 @@ extension VisionPresentationViewController {
         let imageSize = detections.frame.image.size.cgSize
         
         let values = detections.detections.map { detection -> BasicDetection in
-            let rect = detection.boundingBox.convertedToAbsoluteCoordinates(from: detection.boundingBox, relativeTo: imageSize)
+            let rect = detection.boundingBox.convertedToAbsoluteCoordinates(relativeTo: imageSize)
                                             .convertedForAspectRatioFill(from: imageSize, to: detectionsView.bounds.size)
             return BasicDetection(boundingBox: rect, objectType: detection.detectionClass)
         }
@@ -379,10 +379,10 @@ private extension CGRect {
         return CGRect(x: leftTop.x, y: leftTop.y, width: rightBottom.x - leftTop.x, height: rightBottom.y - leftTop.y)
     }
 
-    func convertedToAbsoluteCoordinates(from relativeCoordinates: CGRect, relativeTo frameSize: CGSize) -> CGRect {
-        return CGRect(x: frameSize.width * relativeCoordinates.origin.x,
-                      y: frameSize.height * relativeCoordinates.origin.y,
-                      width: frameSize.width * relativeCoordinates.size.width,
-                      height: frameSize.height * relativeCoordinates.size.height)
+    func convertedToAbsoluteCoordinates(relativeTo frameSize: CGSize) -> CGRect {
+        return CGRect(x: frameSize.width * self.origin.x,
+                      y: frameSize.height * self.origin.y,
+                      width: frameSize.width * self.size.width,
+                      height: frameSize.height * self.size.height)
     }
 }

--- a/MapboxVision/View/VisionPresentationViewController.swift
+++ b/MapboxVision/View/VisionPresentationViewController.swift
@@ -362,7 +362,8 @@ extension VisionPresentationViewController {
         let imageSize = detections.frame.image.size.cgSize
         
         let values = detections.detections.map { detection -> BasicDetection in
-            let rect = detection.boundingBox.convertForAspectRatioFill(from: imageSize, to: detectionsView.bounds.size)
+            let rect = detection.boundingBox.convertedToAbsoluteCoordinates(from:detection.boundingBox, relativeTo:imageSize)
+                                            .convertedForAspectRatioFill(from:imageSize, to:detectionsView.bounds.size)
             return BasicDetection(boundingBox: rect, objectType: detection.detectionClass)
         }
         

--- a/MapboxVision/View/VisionPresentationViewController.swift
+++ b/MapboxVision/View/VisionPresentationViewController.swift
@@ -362,8 +362,8 @@ extension VisionPresentationViewController {
         let imageSize = detections.frame.image.size.cgSize
         
         let values = detections.detections.map { detection -> BasicDetection in
-            let rect = detection.boundingBox.convertedToAbsoluteCoordinates(from:detection.boundingBox, relativeTo:imageSize)
-                                            .convertedForAspectRatioFill(from:imageSize, to:detectionsView.bounds.size)
+            let rect = detection.boundingBox.convertedToAbsoluteCoordinates(from: detection.boundingBox, relativeTo: imageSize)
+                                            .convertedForAspectRatioFill(from: imageSize, to: detectionsView.bounds.size)
             return BasicDetection(boundingBox: rect, objectType: detection.detectionClass)
         }
         

--- a/MapboxVision/View/VisionPresentationViewController.swift
+++ b/MapboxVision/View/VisionPresentationViewController.swift
@@ -372,7 +372,7 @@ extension VisionPresentationViewController {
 }
 
 private extension CGRect {
-    func convertForAspectRatioFill(from: CGSize, to: CGSize) -> CGRect {
+    func convertedForAspectRatioFill(from: CGSize, to: CGSize) -> CGRect {
         let leftTop = origin.convertForAspectRatioFill(from: from, to: to)
         let rightBottom = CGPoint(x: maxX, y: maxY).convertForAspectRatioFill(from: from, to: to)
         return CGRect(x: leftTop.x, y: leftTop.y, width: rightBottom.x - leftTop.x, height: rightBottom.y - leftTop.y)


### PR DESCRIPTION
**MERGE ONLY AFTER mapbox/mapbox-vision#958 is merged**

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
Resolves: #91