### PR TITLE
Allow to return optionals from `geoToWorld` and `worldToGeo` methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added support for UK country
 - Added support for setting attitudeOrient via DeviceMotionData
 - Changed World-Pixel transformation methods to return optional values
+- Changed World-Geo transformation methods to return optional values
 - Removed `MapboxNavigation` dependency
 
 ## 0.4.1

--- a/MapboxVision/VisionManager/BaseVisionManager.swift
+++ b/MapboxVision/VisionManager/BaseVisionManager.swift
@@ -21,11 +21,11 @@ public class BaseVisionManager: VisionManagerProtocol {
         return dependencies.native.world(toPixel: worldCoordinate)
     }
 
-    public func geoToWorld(geoCoordinate: GeoCoordinate) -> WorldCoordinate {
+    public func geoToWorld(geoCoordinate: GeoCoordinate) -> WorldCoordinate? {
         return dependencies.native.geo(toWorld: geoCoordinate)
     }
 
-    public func worldToGeo(worldCoordinates: WorldCoordinate) -> GeoCoordinate {
+    public func worldToGeo(worldCoordinates: WorldCoordinate) -> GeoCoordinate? {
         return dependencies.native.world(toGeo: worldCoordinates)
     }
 

--- a/MapboxVision/VisionManager/VisionManagerProtocol.swift
+++ b/MapboxVision/VisionManager/VisionManagerProtocol.swift
@@ -30,15 +30,17 @@ public protocol VisionManagerProtocol: AnyObject {
      Converts the location of the point from a geographical coordinate to a world coordinate.
 
      - Parameter geoCoordinate: Geographical coordinate of the point
+     - Returns: World coordinate if `geoCoordinate` can be represented in world coordinates and nil otherwise
      */
-    func geoToWorld(geoCoordinate: GeoCoordinate) -> WorldCoordinate
+    func geoToWorld(geoCoordinate: GeoCoordinate) -> WorldCoordinate?
 
     /**
      Converts the location of the point in a world coordinate to a geographical coordinate.
 
      - Parameter worldCoordinate: World coordinate of the point
+     - Returns: Geographical coordinate if `worldCoordinate` can be represented in geographical coordinates and nil otherwise
      */
-    func worldToGeo(worldCoordinates: WorldCoordinate) -> GeoCoordinate
+    func worldToGeo(worldCoordinates: WorldCoordinate) -> GeoCoordinate?
 
     /// :nodoc:
     var native: VisionManagerBaseNative { get }


### PR DESCRIPTION
Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
Resolves: #142 
Depends on #mapbox/mapbox-vision#1177
