### PR TITLE
Set fps using VisionManagerBaseNative

### DIFF
--- a/MapboxVision/VisionManager/BaseVisionManager.swift
+++ b/MapboxVision/VisionManager/BaseVisionManager.swift
@@ -91,18 +91,18 @@ public class BaseVisionManager: VisionManagerProtocol {
     private func updateSegmentationPerformance(_ performance: ModelPerformance) {
         switch ModelPerformanceResolver.coreModelPerformance(for: .segmentation, with: performance) {
         case .fixed(let fps):
-            dependencies.native.config.setSegmentationFixedFPS(fps)
+            dependencies.native.setSegmentationFixedFPS(fps)
         case .dynamic(let minFps, let maxFps):
-            dependencies.native.config.setSegmentationDynamicFPS(minFPS: minFps, maxFPS: maxFps)
+            dependencies.native.setSegmentationDynamicFPS(minFPS: minFps, maxFPS: maxFps)
         }
     }
 
     private func updateDetectionPerformance(_ performance: ModelPerformance) {
         switch ModelPerformanceResolver.coreModelPerformance(for: .detection, with: performance) {
         case .fixed(let fps):
-            dependencies.native.config.setDetectionFixedFPS(fps)
+            dependencies.native.setDetectionFixedFPS(fps)
         case .dynamic(let minFps, let maxFps):
-            dependencies.native.config.setDetectionDynamicFPS(minFPS: minFps, maxFPS: maxFps)
+            dependencies.native.setDetectionDynamicFPS(minFPS: minFps, maxFPS: maxFps)
         }
     }
 


### PR DESCRIPTION
We changed interface of VisionManagerBaseNative in mapbox/mapbox-vision#1264, now it allows to set preferred fps for segmentation/detection models without config, the pr changes the implementation of BaseVisionManager to conform these changes.

Checks:

* [ ] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
mapbox/mapbox-vision#1247