### PR TITLE
Send turnstile event on changing base url

### DIFF
--- a/MapboxVision/Services/EventsManager.swift
+++ b/MapboxVision/Services/EventsManager.swift
@@ -34,6 +34,7 @@ final class EventsManager {
 extension EventsManager: NetworkClient {
     func set(baseURL: URL?) {
         manager.baseURL = baseURL
+        manager.sendTurnstileEvent()
     }
 
     func sendEvent(name: String, entries: [String: Any]) {


### PR DESCRIPTION
Checks:

* [ ] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
Initiated by https://github.com/mapbox/spark-vision-sdk/issues/161 where it was found that there're no turnstile events from China users. That's because `EventsManager` is initialized before the country is known, so if the country is China we don't send turnstile events at all.

We've decided to send a turnstile event each time the country is determined (goes down to `setBaseURL` in `EventsManager`).