### PR TITLE
Roll back to 0.9.5 telemetry

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" == 2.1.0
+binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.2
 binary "https://www.mapbox.com/ios-sdk/opencv.json" ~> 2.4.13
-github "mapbox/mapbox-events-ios" ~> 0.10.2
-github "weichsel/ZIPFoundation" ~> 0.9
+github "mapbox/mapbox-events-ios" ~> 0.9.5
+github "weichsel/ZIPFoundation" ~> 0.9.9

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.1.0"
+binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.0"
 binary "https://www.mapbox.com/ios-sdk/opencv.json" "2.4.13"
-github "mapbox/mapbox-events-ios" "v0.10.2"
+github "mapbox/mapbox-events-ios" "v0.9.5"
 github "weichsel/ZIPFoundation" "0.9.11"

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Vision
 - Added `VisionManager.set(cameraHeight:)`
-- Updated `MapboxMobileEvents` dependency to the version compatible with `0.10.2` version
 - Fixed applying non-BGRA image formats
 
 ### AR

--- a/MapboxVision.podspec
+++ b/MapboxVision.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.swift_version = '4.2'
 
   s.dependency "MapboxVisionNativeAll/Vision", "#{s.version}"
-  s.dependency "MapboxMobileEvents", "~> 0.10.2"
+  s.dependency "MapboxMobileEvents", "~> 0.9.5"
   s.dependency "ZIPFoundation", "~> 0.9.9"
 
 end

--- a/MapboxVision/Core/Telemetry.swift
+++ b/MapboxVision/Core/Telemetry.swift
@@ -30,8 +30,8 @@ final class Telemetry: NSObject, TelemetryInterface {
         manager.sendTurnstileEvent()
     }
 
-    func setSyncUrl(_: String, isChina: Bool) {
-        UserDefaults.mme_configuration().mme_isCNRegion = isChina
+    func setSyncUrl(_ url: String, isChina: Bool) {
+        manager.baseURL = URL(string: url)
         manager.sendTurnstileEvent()
     }
 


### PR DESCRIPTION
`MapboxMobileEvents` library v0.10.2 incorrectly handles certificate pinning for China. Rolling back unless the fix is released.
This PR also upgrades the dependency for `MapboxAccounts` in Cartfile to address #313. The podspec is to be updated in 0.13.0 version of `MapboxVisionNative`.

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues: https://github.com/mapbox/mapbox-vision/issues/2086
