### PR TITLE
Remove vision-ios from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Make Vision iOS and Navigation iOS teams owners for all the files in the repository
-*	@mapbox/vision-ios @mapbox/navigation-ios
+*	@mapbox/navigation-ios


### PR DESCRIPTION
Fixes the validity of codeowners
> Unknown owner on line 2: make sure the team @mapbox/vision-ios exists, is publicly visible, and has write access to the repository
> *	@mapbox/vision-ios @mapbox/navigation-ios